### PR TITLE
Correctly handle parsing of the Time protobuf

### DIFF
--- a/client/src/components/metadataFields.tsx
+++ b/client/src/components/metadataFields.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Field from './field';
 import {objectMap} from './listViewHelpers';
+import {safeParseTimeToDate} from '../utils/dates'
 
 const MetadataFields = ({item}: {[key: string]: any}) => (
     <>
@@ -14,7 +15,7 @@ const MetadataFields = ({item}: {[key: string]: any}) => (
         )}
 
         <Field name='Created'>
-            {new Date(item.metadata.creationTimestamp).toLocaleString()}
+            {safeParseTimeToDate(item.metadata.creationTimestamp).toLocaleString()}
         </Field>
 
         {item.metadata.labels && (

--- a/client/src/utils/dates.ts
+++ b/client/src/utils/dates.ts
@@ -1,4 +1,5 @@
-import HumanizeDuration from 'humanize-duration';
+import HumanizeDuration from "humanize-duration";
+import { k8s } from "../proto/proto";
 
 /**
  * A simple humanizer to merely differentiate between months and minutes.
@@ -21,13 +22,27 @@ const shortEnglishHumanizer = HumanizeDuration.humanizer({
 });
 
 /**
-  * @param epochtimestampMs an epoch timestamp value (in ms)
-  * @returns a "humanized" duration from now
-  *
-  */
-export default function fromNow(epochtimestampMs: number) {
-    const diff = Date.now() - new Date(epochtimestampMs).getTime();
-    return formatDuration(diff);
+ * @param epochtimestampMs an epoch timestamp value (in ms)
+ * @returns a "humanized" duration from now
+ *
+ */
+export default function fromNow(
+  epochtimestampMs: number | string | k8s.io.apimachinery.pkg.apis.meta.v1.ITime
+) {
+  const diff = Date.now() - safeParseTimeToDate(epochtimestampMs).getTime();
+  return formatDuration(diff);
+}
+
+export function safeParseTimeToDate(
+  epochtimestampMs: number | string | k8s.io.apimachinery.pkg.apis.meta.v1.ITime
+) {
+  if (
+    typeof epochtimestampMs !== "number" &&
+    typeof epochtimestampMs !== "string"
+  ) {
+    epochtimestampMs = Number(epochtimestampMs.seconds) * 1000;
+  }
+  return new Date(epochtimestampMs);
 }
 
 


### PR DESCRIPTION
When running this on my cluster, I found a transient bug in the UI. When I initially load the nodes page, it states that the Age is 0s. 
![image](https://user-images.githubusercontent.com/13482895/148705544-57523e36-32a4-4a25-b672-26ea3ddc9aab.png)
However, after waiting a few minutes, it then updates to the correct value:
![image](https://user-images.githubusercontent.com/13482895/148705546-eae63a41-9e1e-4fc9-b6e3-df7c78489d5e.png)

The cause of this bug is that the initial request is read via the protobuf API and the timestamp from there https://github.com/skooner-k8s/skooner/blob/c273b7c0293871fb935fa166eaee6c91141b45d8/client/src/proto/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto#L687 is actually a `Time` object https://github.com/skooner-k8s/skooner/blob/c273b7c0293871fb935fa166eaee6c91141b45d8/client/src/proto/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto#L1009
Unfortunately the date calculation function only expects a number and so the parsing does not work as expected. 

The reason the bug fixes itself is that after a few minutes, a websocket update comes from the cluster. These responses are instead returned in `json`, which returns the value as a `string`, which can be parsed correctly by the `fromNow` function.

https://github.com/skooner-k8s/skooner/blob/18be6ed527d9854346c3a0f181a95b80715da2fa/client/src/services/apiProxy.ts#L165

This PR adds a `safeParseTimeToDate` function to correctly convert the `Time` object to `Date` and fixes the bug for me locally. It also uses the function in the other place I was able to find `Date` being used to parse a timestamp.