### PR TITLE
Use provider.callback() instead of provider.oauthCallback()

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -135,7 +135,7 @@ async function getOidcEndpoint() {
 
 async function oidcAuthenticate(code, redirectUri) {
     const provider = await getOidcProvider();
-    const tokenSet = await provider.oauthCallback(redirectUri, {code}, {});
+    const tokenSet = await provider.callback(redirectUri, {code}, {});
     return tokenSet.id_token;
 }
 


### PR DESCRIPTION
With the upgrade of openif-client to ^5.1.3, oauthCallback() now throws
an exception directing users to callback(), when the response contains
an id_token field.

[Issue305](https://github.com/skooner-k8s/skooner/issues/305)

Test Plan: Built skooner image locally, deployed to microk8s. No longer
an exception in the logs