### PR TITLE
Upgrade node in Dockerfile from 12.4.0 to 12.22.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1 - the build react app
-FROM node:12.4.0-alpine as build-deps
+FROM node:12.22.10-alpine as build-deps
 WORKDIR /usr/src/app
 COPY client/package.json client/package-lock.json ./
 RUN npm i
@@ -8,7 +8,7 @@ COPY client/ ./
 RUN npm run build
 
 # Stage 2 - the production environment
-FROM node:12.4.0-alpine
+FROM node:12.22.10-alpine
 
 RUN apk add --no-cache tini
 ENV NODE_ENV production


### PR DESCRIPTION
I personally ran issue an issue with a bug in Node TLS handling
(https://github.com/nodejs/node/issues/11771). This bug was fixed in
approximately 12.14.0, and does not show up when I test with v12.22.10,
the latest v12 release at the time of this commit.

https://github.com/skooner-k8s/skooner/issues/306

Test Plan: Built image locally, deployed to microk8s cluster. No longer
experiencing issue with parsing TLS certs.

Signed-off-by: Cullen Walsh <ckwalsh@cullenwalsh.com>