### PR TITLE
Fix pod and node views in kube system namespace. 

### DIFF
--- a/client/src/components/nodeCpuChart.tsx
+++ b/client/src/components/nodeCpuChart.tsx
@@ -24,9 +24,9 @@ export default function NodeCpuChart({items, metrics}: {items?: Node[], metrics?
 function getNodeCpuTotals(items?: Node[], metrics?: _.Dictionary<Metrics>) {
     if (!items || !metrics) return null;
 
-    const metricValues = Object.values(metrics);
-    const used = _.sumBy(metricValues, x => parseCpu(x.usage.cpu)) / TO_ONE_CPU;
-    const available = _.sumBy(items, x => parseCpu(x.status.capacity.cpu)) / TO_ONE_CPU;
+    const metricValues = Object.values(metrics) || [];
 
+    const used = _.sumBy(metricValues, x => parseCpu(_.get(x, 'usage.cpu'))) / TO_ONE_CPU;
+    const available = _.sumBy(items, x => parseCpu(_.get(x, 'status.capacity.cpu'))) / TO_ONE_CPU;
     return {used, available};
 }

--- a/client/src/components/nodeRamChart.tsx
+++ b/client/src/components/nodeRamChart.tsx
@@ -33,9 +33,9 @@ export default function NodeRamChart({items, metrics}: {items?: Node[], metrics?
 function getNodeRamTotals(items?: Node[], metrics?: _.Dictionary<Metrics>) {
     if (!items || !metrics) return undefined;
 
-    const metricValues = Object.values(metrics);
-    const used = _.sumBy(metricValues, x => parseRam(x.usage.memory));
-    const available = _.sumBy(items, x => parseRam(x.status.capacity.memory));
+    const metricValues = Object.values(metrics) || [];
 
+    const used = _.sumBy(metricValues, x => parseRam(_.get(x, 'usage.memory')));
+    const available = _.sumBy(items, x => parseRam(_.get(x, 'status.capacity.memory')));
     return {used, available};
 }

--- a/client/src/views/node.tsx
+++ b/client/src/views/node.tsx
@@ -60,7 +60,7 @@ export default class NodeView extends Base<Props, State> {
 
                 <ChartsContainer>
                     <div className='charts_item'>
-                        {item ? (
+                        {item && item.status ? (
                             <span className='charts_number'>{getUptime(item)}</span>
                         ) : (
                             <LoadingChart />
@@ -84,7 +84,8 @@ export default class NodeView extends Base<Props, State> {
                 </ChartsContainer>
 
                 <div className='contentPanel'>
-                    {!item ? <Loading /> : (
+                    {!item && <Loading />}
+                    {item && item.status ? (
                         <div>
                             <MetadataFields item={item} />
                             <Field name='Kernel Version' value={item.status.nodeInfo.kernelVersion} />
@@ -96,12 +97,13 @@ export default class NodeView extends Base<Props, State> {
                             <Field name='Kube Proxy' value={item.status.nodeInfo.kubeProxyVersion} />
                             <Field name='Taints'>{getTaints(item)}</Field>
                         </div>
-                    )}
+                    ) : null}
                 </div>
 
                 <div className='contentPanel_header'>Conditions</div>
                 <div className='contentPanel'>
-                    {!item ? <Loading /> : (
+                    {!item && <Loading />}
+                    {item && item.status ? (
                         <table>
                             <thead>
                                 <tr>
@@ -124,7 +126,7 @@ export default class NodeView extends Base<Props, State> {
                                 ))}
                             </tbody>
                         </table>
-                    )}
+                    ) : null}
                 </div>
 
                 <div className='contentPanel_header'>Pods</div>

--- a/client/src/views/pod.tsx
+++ b/client/src/views/pod.tsx
@@ -50,9 +50,14 @@ export default class PodView extends Base<Props, State> {
         const {item, metrics, events} = this.state || {};
 
         const errors = getErrors(item);
-        const filteredEvents = filterByOwner(events, item);
-        // @ts-ignore
-        const filteredMetrics = getMetrics(item && [item], metrics && [metrics]);
+        let filteredEvents;
+        let filteredMetrics;
+
+        if (item?.metadata) {
+            filteredEvents = filterByOwner(events, item);
+            // @ts-ignore
+            filteredMetrics = getMetrics(item && [item], metrics && [metrics]);
+        }
 
         return (
             <div id='content'>
@@ -87,7 +92,8 @@ export default class PodView extends Base<Props, State> {
                 </ChartsContainer>
 
                 <div className='contentPanel'>
-                    {!item ? <Loading /> : (
+                    {!item && <Loading />}
+                    {item && item.status ? (
                         <div>
                             <MetadataFields item={item} />
                             <Field name='Owned By'>
@@ -123,7 +129,7 @@ export default class PodView extends Base<Props, State> {
                             </Field>
                             <Field name='Selector'>{objectMap(item.spec.nodeSelector)}</Field>
                         </div>
-                    )}
+                    ) : null}
                 </div>
 
                 <ContainersPanel spec={item && item.spec} />


### PR DESCRIPTION
Fixes #276.  There are few instances when an empty object item is returned and various functions called assume if the object exists at all, that it is fully declared.  This PR attempts to check for this in the JSX or called render function if possible.  In the pod component there are several calls directly in the JSX so a the check couldn't be pushed into a common function like in the node component.

Kube System pod before:
<img width="1075" alt="pod-before" src="https://user-images.githubusercontent.com/882485/155874884-8d67d0c2-b283-46e4-8652-43acbe75693f.png">

Kube System pod after:
<img width="1705" alt="pod-after" src="https://user-images.githubusercontent.com/882485/155874898-8bab3a80-cbbd-4b99-8591-0a8fdfac3ae1.png">

Node before:
<img width="1165" alt="node-before" src="https://user-images.githubusercontent.com/882485/155874915-615b3015-b942-451d-916c-43ea2cc289a0.png">

Node after:
<img width="1721" alt="node-after" src="https://user-images.githubusercontent.com/882485/155874933-a9508ce3-3092-43c0-8e4e-9d434b5e96cc.png">

