### PR TITLE
Fix nodeSelector error during installation

### DIFF
--- a/kubernetes-skooner.yaml
+++ b/kubernetes-skooner.yaml
@@ -26,7 +26,7 @@ spec:
           initialDelaySeconds: 30
           timeoutSeconds: 30
       nodeSelector:
-        'beta.kubernetes.io/os': linux
+        'kubernetes.io/os': linux
 
 ---
 kind: Service


### PR DESCRIPTION
This PR fixes the following issue during installation:

```
PS /> kubectl apply -f https://raw.githubusercontent.com/skooner-k8s/skooner/master/kubernetes-skooner.yaml

Warning: spec.template.spec.nodeSelector[beta.kubernetes.io/os]: deprecated since v1.14; use "kubernetes.io/os" instead
deployment.apps/skooner created
service/skooner created
```

I'm running Kubernetes 1.23 on Linode LKE