### PR TITLE
Updating namespace to Skooner

### DIFF
--- a/kubernetes-skooner-nodeport.yaml
+++ b/kubernetes-skooner-nodeport.yaml
@@ -1,8 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: skooner
+---
 kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: skooner
-  namespace: kube-system
+  namespace: skooner
 spec:
   replicas: 1
   selector:
@@ -33,7 +38,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: skooner
-  namespace: kube-system
+  namespace: skooner
 spec:
   type: NodePort
   ports:

--- a/kubernetes-skooner-oidc.yaml
+++ b/kubernetes-skooner-oidc.yaml
@@ -1,8 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: skooner
+---
 kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: skooner
-  namespace: kube-system
+  namespace: skooner
 spec:
   replicas: 1
   selector:
@@ -49,7 +54,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: skooner
-  namespace: kube-system
+  namespace: skooner
 spec:
   ports:
     - port: 80

--- a/kubernetes-skooner-serviceaccount.yaml
+++ b/kubernetes-skooner-serviceaccount.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  namespace: skooner
   name: skooner-sa
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -14,5 +15,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: skooner-sa
-  namespace: default
+  namespace: skooner
 ---

--- a/kubernetes-skooner.yaml
+++ b/kubernetes-skooner.yaml
@@ -1,8 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: skooner
+---
 kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: skooner
-  namespace: kube-system
+  namespace: skooner
 spec:
   replicas: 1
   selector:
@@ -33,7 +38,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: skooner
-  namespace: kube-system
+  namespace: skooner
 spec:
   ports:
     - port: 80


### PR DESCRIPTION
Deploy skooner to `skooner` namespace instead of `kube-system`. This is good practice to keep applications in separate namespaces.