### PR TITLE
Fix missing ingress in k8s 1.22+

### DIFF
--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -32,7 +32,7 @@ const hpa = apiFactoryWithNamespace('autoscaling', 'v1', 'horizontalpodautoscale
 const cronJob = apiFactoryWithNamespace('batch', 'v1beta1', 'cronjobs');
 const job = apiFactoryWithNamespace('batch', 'v1', 'jobs');
 
-const ingress = apiFactoryWithNamespace('extensions', 'v1beta1', 'ingresses');
+const ingress = apiFactoryWithNamespace('networking.k8s.io', 'v1', 'ingresses');
 
 const storageClass = apiFactory<StorageClass>('storage.k8s.io', 'v1', 'storageclasses');
 


### PR DESCRIPTION
Current official k8s version is 1.22 https://kubernetes.io/releases/
So supporting deprecated extensions/v1beta1 is not needed

It fixes issue https://github.com/skooner-k8s/skooner/issues/311