### PR TITLE
Allow access_token

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -21,6 +21,7 @@ const OIDC_SECRET = process.env.OIDC_SECRET;
 const OIDC_URL = process.env.OIDC_URL;
 const OIDC_SCOPES = process.env.OIDC_SCOPES || 'openid email';
 const OIDC_USE_PKCE = process.env.OIDC_USE_PKCE === "true" || false;
+const OIDC_USE_ACCESS_TOKEN = process.env.OIDC_USE_ACCESS_TOKEN === "true" || false;
 const OIDC_METADATA = JSON.parse(process.env.OIDC_METADATA || '{}');
 const clientMetadata = Object.assign({client_id: OIDC_CLIENT_ID, client_secret: OIDC_SECRET}, OIDC_METADATA);
 
@@ -209,6 +210,10 @@ async function oidcAuthenticate(code, redirectUri) {
         }
     }
     const tokenSet = await provider.callback(redirectUri, {code}, authCheckParams);
+ 
+    if ( OIDC_USE_ACCESS_TOKEN ) {
+        return tokenSet.access_token;
+    }
     return tokenSet.id_token;
 }
 


### PR DESCRIPTION
I am trying to set up skooner using OIDC auth, and we already are using the azure and[ kubelogin ](https://github.com/Azure/kubelogin) for human access as well as in CI/CD, we would like to use the same for skooner as well where there is server app on the cluster side and the client app which has delegated permissions on the server app

we have to pass the OIDC_SCOPE as <`server-app-id`>/scope name in addition to openid which returns the access token with the audience field set to the server-app-id, but the code is hardcoded to use id_token always, this diff introduces new environment variable `OIDC_USE_ACCESS_TOKEN` to use access_token